### PR TITLE
Reduce the speed at which the pegasun reproduce

### DIFF
--- a/mods/animals/pegasun.lua
+++ b/mods/animals/pegasun.lua
@@ -12,7 +12,7 @@ local random = math.random
 --energy
 local energy_max = 8000--secs it can survive without food
 local energy_egg = energy_max/2 --energy that goes to egg
-local egg_timer  = 60*25
+local egg_timer  = 120*25
 local young_per_egg = 1		--will get this/energy_egg starting energy
 
 local lifespan = energy_max * 10
@@ -129,7 +129,7 @@ local function brain(self)
 							if mate then
 								--go get him!
 								mobkit.make_sound(self,'mating')
-								animals.hq_mate(self, 25, mate)
+								if random() < 0.25 then animals.hq_mate(self, 25, mate) end
 							end
 						end
 					else


### PR DESCRIPTION
**SUMMARY**
Increases the time for Pegasun eggs to hatch and reduces odds of pregnancy from mating

**DESCRIPTION**
Pegasun population explosions are irksome, and this PR seeks to mitigate the trouble. Making eggs take longer to hatch gives players more time to scoop them up, and slows the rate at which new Pegasuns appear. Also, it's a bit much for every mating to successfully impregnate the female, especially for birds who have to rely on gravity and internal pressure to get the sperm where it needs to go. Therefore, I've set the mating to have a 1-in-4 chance of success, which seemed reasonable to me.

**ADDITIONAL INFO**
Local testing shows the pegasun population, which had once overrun my local map, has now become manageable. After laboriously exterminating the surplus population, they've shown a slowly growing population which needs only occasional culling, instead of all-out war.
 It might be good to prevent mating in winter, too, as that was the worst period of expansion (seeing as how I couldn't go outside for long and they kept spreading unchecked) but I haven't done so yet.
